### PR TITLE
Add environment configuration

### DIFF
--- a/enviroments.json5
+++ b/enviroments.json5
@@ -1,0 +1,9 @@
+{
+  // Path to Stable Diffusion WebUI
+  "api_path": "I:/stable-diffusion-webui-forge",
+  // URL to Stable Diffusion API
+  "api_url": "http://localhost:7860",
+  // URL to PEM API
+  "pem_api": "http://localhost:7865"
+}
+

--- a/modules/api/v1/items/sdapi.py
+++ b/modules/api/v1/items/sdapi.py
@@ -5,9 +5,7 @@ from typing import *
 from fastapi import status
 from utils import *
 
-async def get(
-  path: str
-):
+async def get(path: str) -> Any:
   response = await shared.session.get(
     url=api_url + path,
     headers={"Content-Type": "application/json"}
@@ -19,21 +17,21 @@ async def get(
     return {"success": False, "message": f"Failed to retrieve data ({response.status_code})"}, status.HTTP_500_INTERNAL_SERVER_ERROR
 
 @app.get("/v1/items/sdapi/samplers")
-async def get_samplers():
+async def get_samplers() -> tuple[list[str], int]:
   unresized = await get("/sdapi/v1/samplers")
   return [
     x["name"] for x in unresized if "name" in x
   ], status.HTTP_200_OK
 
 @app.get("/v1/items/sdapi/schedulers")
-async def get_schedulers():
+async def get_schedulers() -> tuple[list[str], int]:
   unresized = await get("/sdapi/v1/schedulers")
   return [
     x["label"] for x in unresized if "label" in x
   ], status.HTTP_200_OK
 
 @app.get("/v1/items/sdapi/sd_models")
-async def get_sd_models():
+async def get_sd_models() -> tuple[list[str], int]:
   unresized = await get("/sdapi/v1/sd-models")
   return [
     x["model_name"] for x in unresized if "model_name" in x

--- a/modules/forever/from_lora.py
+++ b/modules/forever/from_lora.py
@@ -52,7 +52,7 @@ class LegacyImageProgressAPI:
         """
         
 class ForeverGenerationFromLoRA(ForeverGeneration):
-  def stdout(self, txt = None, silent = False):
+  def stdout(self, txt: str | None = None, silent: bool = False) -> str:
     if txt is None: return self.output
     if not silent: println(f"[Forever]: {txt}")
     self.output += txt + "\n"
@@ -72,7 +72,7 @@ class ForeverGenerationFromLoRA(ForeverGeneration):
     self.image_skipped = True
     return True
 
-  def __init__(self, payload: dict = None):
+  def __init__(self, payload: dict | None = None) -> None:
     super().__init__({})
     self.output = ""
     self.payload = {}
@@ -131,16 +131,16 @@ class ForeverGenerationFromLoRA(ForeverGeneration):
   # @override
   async def start(
     self,
-    lora, blacklist, pattern_blacklist,
-    blacklist_multiplier, use_relative_freq,
-    w_multiplier, w_min, w_max,
-    disallow_duplicate, header, footer,
-    max_tags, base_chance, add_lora_name, lora_weight,
-    s_method, scheduler, steps_min, steps_max,
-    cfg_min, cfg_max, batch_count, batch_size,
-    size, adetailer, enable_hand_tap,
-    disable_lora_in_adetailer, enable_freeu, preset,
-    negative
+    lora: list[str], blacklist: str, pattern_blacklist: str,
+    blacklist_multiplier: float, use_relative_freq: bool,
+    w_multiplier: float, w_min: int, w_max: int,
+    disallow_duplicate: bool, header: str, footer: str,
+    max_tags: int, base_chance: float, add_lora_name: bool, lora_weight: float,
+    s_method: list[str], scheduler: list[str], steps_min: int, steps_max: int,
+    cfg_min: float, cfg_max: float, batch_count: int, batch_size: int,
+    size: str, adetailer: bool, enable_hand_tap: bool,
+    disable_lora_in_adetailer: bool, enable_freeu: bool, preset: str,
+    negative: str
   ) -> AsyncGenerator[tuple[str, Image.Image], None]:
     self.default_prompt_request_param = {
       "lora_name": lora,

--- a/modules/forever_generation.py
+++ b/modules/forever_generation.py
@@ -6,7 +6,7 @@ from modules.generate import Txt2imgAPI
 
 
 class ForeverGeneration(abc.ABC):
-    def __init__(self, payload: dict, *args, **kwargs):
+    def __init__(self, payload: dict, *args: Any, **kwargs: Any) -> None:
         self._payload = payload.copy()
         self.is_generating = False
         self._stop_event = asyncio.Event()
@@ -15,7 +15,7 @@ class ForeverGeneration(abc.ABC):
     async def get_payload(self) -> dict:
         raise NotImplementedError
 
-    async def generate_forever(self, **override_payload) -> AsyncGenerator[dict, None]:
+    async def generate_forever(self, **override_payload: Any) -> AsyncGenerator[dict, None]:
         """
         payloadを取得する関数を受け取り生成を続ける
 
@@ -61,7 +61,7 @@ class ForeverGeneration(abc.ABC):
             print("Generation stopped.")
         return
 
-    async def stop_generation(self):
+    async def stop_generation(self) -> None:
         self._stop_event.set()
         self.is_generating = False
         println("Generation stopped by user.")

--- a/modules/generate.py
+++ b/modules/generate.py
@@ -63,7 +63,7 @@ class GenerationResult(BaseModel):
 
 
 class Txt2imgAPI:
-    def __init__(self, payload: dict):
+    def __init__(self, payload: dict) -> None:
         self.payload = payload.copy()
 
     @staticmethod
@@ -131,7 +131,7 @@ class Txt2imgAPI:
             print_critical(f"Error generating image: {e}")
             yield None, None, None
 
-    async def get_progress(self):
+    async def get_progress(self) -> Optional[GenerationProgress]:
         try:
             progress = await self._get_requests("/sdapi/v1/progress", {})
             cls = GenerationProgress(

--- a/modules/tabs/forever_generation.py
+++ b/modules/tabs/forever_generation.py
@@ -3,13 +3,13 @@ import os
 from webui import UiTabs
 
 class Define(UiTabs):
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         super().__init__(path)
 
         self.child_path = os.path.join(UiTabs.PATH, "forever_generations")
 
-    def title(self):
+    def title(self) -> str:
         return "Forever Image Generation"
 
-    def index(self):
+    def index(self) -> int:
         return 0

--- a/modules/tabs/forever_generations/from_lora.py
+++ b/modules/tabs/forever_generations/from_lora.py
@@ -4,16 +4,17 @@ import gradio as gr
 import os
 import shared
 import requests
+from typing import Callable, List
 from utils import *
 
 class LoRAToPrompt(UiTabs):
-  def title(self):
+  def title(self) -> str:
     return "from LoRA"
-  def index(self):
+  def index(self) -> int:
     return 1
-  def ui(self, outlet):
+  def ui(self, outlet: Callable[[str, gr.components.Component], None]) -> None:
     instance = ForeverGenerationFromLoRA()
-    def get_opts(mode: str):
+    def get_opts(mode: str) -> List[str]:
       resp = requests.get(f"{shared.pem_api}/v1/items/sdapi/{mode}")
       
       if resp.status_code != 200:

--- a/modules/tabs/prompt_generator.py
+++ b/modules/tabs/prompt_generator.py
@@ -3,13 +3,13 @@ import os
 from webui import UiTabs
 
 class Define(UiTabs):
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         super().__init__(path)
 
         self.child_path = os.path.join(UiTabs.PATH, "prompt_generators")
 
-    def title(self):
+    def title(self) -> str:
         return "Prompt Generator"
 
-    def index(self):
+    def index(self) -> int:
         return 1

--- a/modules/tabs/prompt_generators/from_lora.py
+++ b/modules/tabs/prompt_generators/from_lora.py
@@ -2,21 +2,22 @@ from webui import UiTabs
 import gradio as gr
 import os
 import shared
+from typing import Callable
 from utils import *
 
 class LoRAToPrompt(UiTabs):
-  def title(self):
+  def title(self) -> str:
     return "from LoRA"
-  def index(self):
+  def index(self) -> int:
     return 1
-  def ui(self, outlet):
+  def ui(self, outlet: Callable[[str, gr.components.Component], None]) -> None:
     async def generate_prompt(
       lora_names, blacklist, pattern_blacklist,
       blacklist_multiplier, use_relative_freq,
       weight_multiplier, w_min, w_max,
       disallow_duplicate, header, footer,
       max_tags, base_chance, add_lora_name, lora_weight
-    ):
+    ) -> str:
       prm = {
         "lora_name": lora_names,
         "blacklist": blacklist.split(",") if blacklist else [],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ uvicorn
 gradio==3.49.0
 starlette
 httpx
+pyjson5

--- a/shared.py
+++ b/shared.py
@@ -1,11 +1,15 @@
 from fastapi import FastAPI
-from typing import Optional
-from utils import printwarn
+from typing import Optional, Dict, Any
+from utils import printwarn, update_enviroments
 import httpx
+import os
 
 app = FastAPI()
-api_path = "I:/stable-diffusion-webui-forge"
-api_url = "http://localhost:7860"
-pem_api = "http://localhost:7865"
+env: Dict[str, Any] = update_enviroments()
+api_path: str = env.get("api_path", "I:/stable-diffusion-webui-forge")
+api_url: str = env.get("api_url", "http://localhost:7860")
+pem_api: str = env.get("pem_api", "http://localhost:7865")
 
-session: httpx.AsyncClient = httpx.AsyncClient(headers={"Content-Type": "application/json"}, timeout=None)
+session: httpx.AsyncClient = httpx.AsyncClient(
+    headers={"Content-Type": "application/json"}, timeout=None
+)

--- a/utils.py
+++ b/utils.py
@@ -1,4 +1,7 @@
 import datetime
+import os
+from typing import Any, Dict
+import pyjson5
 
 class AnsiColors:
     GREEN = '\033[92m'
@@ -8,17 +11,33 @@ class AnsiColors:
     GRAY = '\033[90m'
     RESET = '\033[0m'
 
-def now():
+def now() -> str:
   return datetime.datetime.now().strftime("%H:%M:%S")
 
-def println(*args, **kw):
-  return print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.GREEN}INFO{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
+def println(*args: Any, **kw: Any) -> None:
+  print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.GREEN}INFO{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
 
-def printerr(*args, **kw):
-  return print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.RED}ERROR{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
+def printerr(*args: Any, **kw: Any) -> None:
+  print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.RED}ERROR{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
 
-def printwarn(*args, **kw):
-  return print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.YELLOW}WARN{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
+def printwarn(*args: Any, **kw: Any) -> None:
+  print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.YELLOW}WARN{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
 
-def print_critical(*args, **kw):
-  return print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.BOLD}{AnsiColors.RED}CRITICAL!{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
+def print_critical(*args: Any, **kw: Any) -> None:
+  print(f"{AnsiColors.GRAY}[{now()}] {AnsiColors.BOLD}{AnsiColors.RED}CRITICAL!{AnsiColors.RESET} {' '.join(map(str, args))}", **kw)
+
+
+def update_enviroments(path: str = "enviroments.json5") -> Dict[str, Any]:
+  """Load environment variables from a JSON5 file and update os.environ."""
+  if not os.path.exists(path):
+    printwarn(f"Environment file {path} not found.")
+    return {}
+  try:
+    with open(path, "r", encoding="utf-8") as f:
+      data: Dict[str, Any] = pyjson5.load(f)
+    for k, v in data.items():
+      os.environ[k] = str(v)
+    return data
+  except Exception as e:
+    printwarn(f"Failed to load environments: {e}")
+    return {}

--- a/webui.py
+++ b/webui.py
@@ -8,7 +8,7 @@ import gradio as gr
 class UiTabs:
     PATH = os.path.join(os.getcwd(), "modules/tabs")
 
-    def __init__(self, path):
+    def __init__(self, path: str) -> None:
         self.filepath = path
         self.rootpath = UiTabs.PATH
         self.child_path = None
@@ -22,7 +22,7 @@ class UiTabs:
         """return ui's index"""
         return 0
 
-    def get_ui(self) -> list:
+    def get_ui(self) -> List[UiTabs]:
         tabs = []
         files = [file for file in os.listdir(self.child_path) if file.endswith(".py")]
         # print(f"Child path: {self.child_path} ({files})")
@@ -54,7 +54,7 @@ class UiTabs:
         )
         return tabs
 
-    def ui(self, outlet: Callable):
+    def ui(self, outlet: Callable[[str, gr.components.Component], None]) -> None:
         """make ui data
         don't return"""
         with gr.Blocks():
@@ -162,7 +162,7 @@ def make_ui() -> tuple[gr.Blocks, dict]:
     return block, {}
 
 
-def register_apps():
+def register_apps() -> None:
     modules_root_dir = os.path.join(os.getcwd(), "modules/api")
     for root, _, files in os.walk(modules_root_dir):
         for filename in files:
@@ -185,7 +185,7 @@ import uvicorn
 import threading
 
 
-def launch():
+def launch() -> None:
     register_apps()
     threading.Thread(
         target=uvicorn.run,


### PR DESCRIPTION
## Summary
- centralize API environment settings in `enviroments.json5`
- load environment file with new `update_enviroments` helper
- update `shared.py` to read configurable variables
- require `pyjson5` for JSON5 parsing

## Testing
- `python3 -m py_compile $(find . -path './legacy' -prune -o -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_6842ee2d89008332a7e24dae4c670a12